### PR TITLE
添加跳过音频文件路径检测的选项

### DIFF
--- a/AIChat/AIMod.cs
+++ b/AIChat/AIMod.cs
@@ -35,6 +35,7 @@ namespace ChillAIMod
         private ConfigEntry<string> _TTSServicePathConfig;
         private ConfigEntry<bool> _LaunchTTSServiceConfig;
         private ConfigEntry<bool> _quitTTSServiceOnQuitConfig;
+        private ConfigEntry<bool> _skipAudioPathCheckConfig;
 
         // --- 新增窗口大小配置 ---
         private ConfigEntry<float> _windowWidthConfig;
@@ -129,6 +130,7 @@ namespace ChillAIMod
             _TTSServicePathConfig = Config.Bind("2. Audio", "TTS_Service_Path", @"D:\GPT-SoVITS\GPT-SoVITS-v2pro-20250604-nvidia50\run_api.bat", "TTS Service Path");
             _LaunchTTSServiceConfig = Config.Bind("2. Audio", "LaunchTTSService", true, "是否在游戏启动时自动启动 TTS 服务");
             _quitTTSServiceOnQuitConfig = Config.Bind("2. Audio", "QuitTTSServiceOnQuit", true, "是否在游戏退出时自动关闭 TTS 服务");
+            _skipAudioPathCheckConfig = Config.Bind("2. Audio", "SkipAudioPathCheck", false, "不检测音频文件路径（用 docker 部署 TTS 时请勾选）");
             _promptTextConfig = Config.Bind("2. Audio", "PromptText", "君が集中した時のシータ波を検出して、リンクをつなぎ直せば元通りになるはず。", "Ref Audio Text");
             _promptLangConfig = Config.Bind("2. Audio", "PromptLang", "ja", "Ref Lang");
             _targetLangConfig = Config.Bind("2. Audio", "TargetLang", "ja", "Target Lang");
@@ -393,6 +395,7 @@ namespace ChillAIMod
                 GUILayout.Space(5);
                 _LaunchTTSServiceConfig.Value = GUILayout.Toggle(_LaunchTTSServiceConfig.Value, "启动时自动运行 TTS 服务", GUILayout.Height(elementHeight));
                 _quitTTSServiceOnQuitConfig.Value = GUILayout.Toggle(_quitTTSServiceOnQuitConfig.Value, "退出时自动关闭 TTS 服务", GUILayout.Height(elementHeight));
+                _skipAudioPathCheckConfig.Value = GUILayout.Toggle(_skipAudioPathCheckConfig.Value, "不检测音频文件路径", GUILayout.Height(elementHeight));
                 GUILayout.EndVertical(); // <--- 必须结束！
 
                 GUILayout.Space(5);
@@ -785,7 +788,10 @@ namespace ChillAIMod
                         _promptTextConfig.Value,
                         _promptLangConfig.Value,
                         Logger,
-                        (clip) => downloadedClip = clip));
+                        (clip) => downloadedClip = clip,
+                        3,
+                        30f,
+                        _skipAudioPathCheckConfig.Value));
 
                     if (downloadedClip != null)
                     {

--- a/AIChat/Services/TTSClient.cs
+++ b/AIChat/Services/TTSClient.cs
@@ -24,13 +24,10 @@ namespace AIChat.Services
             ManualLogSource logger,
             Action<AudioClip> onComplete, 
             int maxRetries = 3, 
-            float timeoutSeconds = 30f)
+            float timeoutSeconds = 30f,
+            bool skipAudioPathCheck = false)
         {
-            logger.LogInfo("[TTS] 开始生成语音...");
-
-
-
-            if (!File.Exists(refPath))
+            if (!skipAudioPathCheck && !File.Exists(refPath))
             {
                 string defaultPath = Path.Combine(BepInEx.Paths.PluginPath, "ChillAIMod", "Voice.wav");
                 if (File.Exists(defaultPath)) refPath = defaultPath;
@@ -49,6 +46,12 @@ namespace AIChat.Services
                 ""prompt_text"": ""{ResponseParser.EscapeJson(promptText)}"", 
                 ""prompt_lang"": ""{promptLang}"" 
             }}";
+
+            // Log the complete TTS API request before starting generation
+            logger.LogInfo($"[TTS] 完整请求信息:");
+            logger.LogInfo($"[TTS]   URL: {url}");
+            logger.LogInfo($"[TTS]   Request Body: {jsonBody}");
+            logger.LogInfo("[TTS] 开始生成语音...");
 
             for (int attempt = 1; attempt <= maxRetries; attempt++)
             {


### PR DESCRIPTION
如题；同时在日志中输出完整的 TTS API 请求，以供排查问题。

此 PR 的必要性说明：
- GPT-SoVITS 可能部署在其他机器上，而即使部署在本地，也可能是使用 docker 部署的，这些情况下，TTS 服务访问的音频文件路径与 mod 所访问的路径不一致（mod 其实也不需要访问音频文件），不应当从 mod 一侧检测其存在性。
- 另外，在 Linux 下（注：docker 本身也是 Linux 环境）GPT-SoVITS 的路径是不带盘符的格式（ `/foo/bar`），而本 Mod 由于在 Proton 中运行（注：steam 在 Linux 运行 Windows 游戏采用的就是 Proton），采用 `Z:\foo\bar` 的这种格式，是无论如何也无法统一的。
